### PR TITLE
General improvements, mostly for macOS

### DIFF
--- a/game/GLGame.cpp
+++ b/game/GLGame.cpp
@@ -69,6 +69,7 @@ GL::Game::Game(Callback callback, HighScoreNameCallback highScoreCallback, void 
     , accumulator(0)
     , playing(false)
     , pausing(false)
+    , gameOver(false)
     , evenFrame(true)
     , flapKeyDown(false)
     , showFPS_(false)
@@ -302,6 +303,8 @@ void GL::Game::drawFrame() const
         drawPlayer();
         drawEnemies();
         drawObelisks();
+    }
+    if (playing || gameOver) {
         drawLivesNumbers();
         drawScoreNumbers();
         drawLevelNumbers();
@@ -440,6 +443,7 @@ void GL::Game::newGame()
     livesLeft = kInitNumLives;
     score_ = 0L;
     playing = true;
+    gameOver = false;
     pausing = false;
     numOwls = 4;
     closeWall();
@@ -471,6 +475,7 @@ bool GL::Game::paused() const
 void GL::Game::endGame()
 {
     playing = false;
+    gameOver = true;
     sounds.play(kMusicSound);
     checkHighScore();
     cursor.show();
@@ -1297,6 +1302,9 @@ void GL::Game::drawLivesNumbers() const
 {
 	int digit;
 	
+    if (livesLeft == 0) {
+        return;
+    }
 	digit = (livesLeft - 1) / 10;
 	digit = digit % 10L;
 	if ((digit == 0) && ((livesLeft - 1) < 100)) {

--- a/game/GLGame.cpp
+++ b/game/GLGame.cpp
@@ -420,8 +420,9 @@ void GL::Game::drawLightning() const
     }
     
     Renderer *r = renderer_;
+    float scale = r->bounds().width() / GL_GAME_WIDTH;
     r->setFillColor(1.0, 1.0, 0);
-    r->beginLines(2.0f);
+    r->beginLines(1.0f * scale, false);
     r->moveTo(leftLightningPts[0].h, leftLightningPts[0].v);
     for (int i = 0; i < kNumLightningPts - 1; i++) {
         r->moveTo(leftLightningPts[i].h, leftLightningPts[i].v);

--- a/game/GLGame.cpp
+++ b/game/GLGame.cpp
@@ -2837,8 +2837,8 @@ void GL::Game::showAbout()
 
 void GL::Game::drawAbout(Renderer *r) const
 {
-    int x = (r->bounds().width() - aboutImg.width()) / 2;
-    int y = (r->bounds().height() - aboutImg.height()) / 2;
+    int x = (GL_GAME_WIDTH - aboutImg.width()) / 2;
+    int y = (GL_GAME_HEIGHT - aboutImg.height()) / 2;
     
     aboutImg.draw(x, y);
 

--- a/game/GLGame.h
+++ b/game/GLGame.h
@@ -139,7 +139,7 @@ private:
     double lastTime;
     double accumulator;
     void loadImages();
-    bool playing, pausing, evenFrame, flapKeyDown;
+    bool playing, pausing, gameOver, evenFrame, flapKeyDown;
 
     bool showFPS_;
     double fps_time;

--- a/game/GLImage.cpp
+++ b/game/GLImage.cpp
@@ -57,6 +57,7 @@ void GL::Image::draw(const GL::Point *dest, size_t numDest, const GL::Point *src
 
     // GL_NEAREST affects drawing the texture at different sizes
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 	
 	// draw the texture
 	glBegin(numDest == 4 ? GL_QUADS : GL_POLYGON);

--- a/game/GLSounds.h
+++ b/game/GLSounds.h
@@ -50,7 +50,6 @@ public:
             case kBoom2Sound:
             case kSplashSound:
             case kFlapSound:
-            case kLightningSound:
             case kWalkSound:
                 return 3;
             case kSpawnSound:
@@ -59,6 +58,8 @@ public:
             case kScrape2Sound:
             case kScreechSound:
                 return 8;
+            case kLightningSound:
+                return 24;
         }
         return 1;
     }

--- a/mac/main.mm
+++ b/mac/main.mm
@@ -385,6 +385,9 @@ static CVReturn displayLinkCallback(CVDisplayLinkRef displayLink __unused, const
 
 - (void)doKey:(NSEvent *)event up:(BOOL)up
 {
+    if (!game_->paused()) {
+        [NSCursor setHiddenUntilMouseMoves:YES];
+    }
     NSString *chars = [event characters];
     for (NSUInteger i = 0; i < [chars length]; ++i) {
         unichar ch = [chars characterAtIndex:i];

--- a/mac/main.mm
+++ b/mac/main.mm
@@ -153,11 +153,13 @@ static void highScoreNameCallback(const char *highName, int place, void *context
 
 - (void)windowDidExitFullScreen:(NSNotification * __unused)notification
 {
+    [NSMenu setMenuBarVisible: YES];
     [fullScreen_ setTitle:@"Enter Full Screen"];
 }
 
 - (void)windowDidEnterFullScreen:(NSNotification * __unused)notification
 {
+    [NSMenu setMenuBarVisible: NO];
     [fullScreen_ setTitle:@"Exit Full Screen"];
 }
 


### PR DESCRIPTION
I've implemented the suggestions in #10 and a few more improvements:

General improvements:
* Use `GL_NEAREST` for upscaling: will not be blurry on retina screens
* Preload more lightning sounds: while not playing, you can click faster before the sound fails to play
* Keep score and level on bottom bar after the game is over: I chose to hide the lives since the game is over when you have no lives left

macOS-specific:
* Allow resizing the window to integer multiples of the game size (to keep pixel-perfect drawing, including ½ on retina screens)
* Hide cursor while playing, even if it is moved (while playing, it re-hides on keyboard input) 
* Full screen enhancements
  * Scales up to nearest integer multiple of the game size (to keep pixel-perfect drawing)
  * Hide the menubar

![retina half size](https://github.com/kainjow/Glypha/assets/158216/0479502f-2bf9-451f-b868-38b1c742870f)
![retina default size](https://github.com/kainjow/Glypha/assets/158216/dcbab800-a058-4891-9255-f3713fb4ac70)
![non-retina 2x game over](https://github.com/kainjow/Glypha/assets/158216/e20802a2-0fa4-474a-abda-150fe8766dbe)
